### PR TITLE
Generate the digest using the .file method

### DIFF
--- a/lib/bagit/manifest.rb
+++ b/lib/bagit/manifest.rb
@@ -26,14 +26,13 @@ module BagIt
       # manifest each tag file for each algorithm
       bag_files.each do |f|
         rel_path = Pathname.new(f).relative_path_from(Pathname.new(bag_dir)).to_s
-        data = open(f) { |io| io.read }
-
+        
         # sha1
-        sha1 = Digest::SHA1.hexdigest data
+        sha1 = Digest::SHA1.file f
         open(manifest_file(:sha1), 'a') { |io| io.puts "#{sha1} #{rel_path}" }
 
         # md5
-        md5 = Digest::MD5.hexdigest data
+        md5 = Digest::MD5.file f
         open(manifest_file(:md5), 'a') { |io| io.puts "#{md5} #{rel_path}" }
       end
 


### PR DESCRIPTION
doing it this way does not require loading the whole file in memory, which for big files is a definite plus

see http://rdocs.stevedev.com/stdlib/libdoc/digest/rdoc/classes/Digest/Class.html#M000535
and http://rdocs.stevedev.com/stdlib/libdoc/digest/rdoc/classes/Digest/Instance.html#M000516

for more implementation details.

otoh, you need to read the file twice. But those are the trade offs.
