### PR TITLE
Fix fetch location (fixed #12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 rvm:
+  - "2.0.0"
   - "1.9.3"
   - "1.9.2"
   - "1.8.7"
@@ -6,3 +7,4 @@ rvm:
 branches:
   only:
     - master
+    - get_working_with_travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ rvm:
 branches:
   only:
     - master
-    - get_working_with_travis

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ Bundler::GemHelper.install_tasks
 
 RSpec::Core::RakeTask.new do |t|
   t.pattern = 'spec/**/*_spec.rb'
-  t.rspec_opts = %w(-fs --color)
+  t.rspec_opts = %w(-fd --color)
 end
 
 task :default => [:spec]

--- a/bagit.gemspec
+++ b/bagit.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rdoc'
   spec.add_development_dependency 'rspec'
 
   spec.files         = `git ls-files`.split($/)

--- a/lib/bagit/fetch.rb
+++ b/lib/bagit/fetch.rb
@@ -16,7 +16,7 @@ module BagIt
       end
     end
 
-    # feth all remote files
+    # fetch all remote files
     def fetch!
 
       open(fetch_txt_file) do |io|
@@ -24,9 +24,12 @@ module BagIt
         io.readlines.each do |line|
           
           (url, length, path) = line.chomp.split(/\s+/, 3)
-          
-          add_file(path) do |io|
-            io.write open(url)
+
+          if path =~ /^data\//
+            path.gsub!(/^data\//, '')
+            add_file(path) do |io|
+              io.write open(url)
+            end
           end
           
         end

--- a/lib/bagit/fetch.rb
+++ b/lib/bagit/fetch.rb
@@ -9,9 +9,11 @@ module BagIt
     end
 
     def add_remote_file(url, path, size, sha1, md5)
-      open(fetch_txt_file, 'a') { |io| io.puts "#{url} #{size || '-'} #{path}" }
-      open(manifest_file('sha1'), 'a') { |io| io.puts "#{sha1} #{File.join 'data', path}" }
-      open(manifest_file('md5'), 'a') { |io| io.puts "#{md5} #{File.join 'data', path}" }
+      if path =~ /^data\//
+        open(fetch_txt_file, 'a') { |io| io.puts "#{url} #{size || '-'} #{path}" }
+        open(manifest_file('sha1'), 'a') { |io| io.puts "#{sha1} #{File.join path}" }
+        open(manifest_file('md5'), 'a') { |io| io.puts "#{md5} #{File.join path}" }
+      end
     end
 
     # feth all remote files

--- a/spec/bagit_spec.rb
+++ b/spec/bagit_spec.rb
@@ -41,7 +41,7 @@ describe BagIt::Bag do
     end
 
     it "should be a directory" do
-      File.directory?(@bag_path).should be_true
+      @bag_path.should be_a_directory
     end
 
     it "should not be empty" do
@@ -50,7 +50,7 @@ describe BagIt::Bag do
 
     it "should have a sub-directory called data" do
       data_path = File.join @bag_path, 'data'
-      File.directory?(data_path).should be_true
+      File.join(@bag_path, 'data').should be_a_directory
     end
 
     describe "#add_file" do
@@ -151,9 +151,9 @@ describe BagIt::Bag do
         f = File.join "1", "2", "3", "file"
         @bag.add_file(f) { |io| io.puts 'all alone' }
         @bag.remove_file f
-        File.exist?(File.dirname(File.join(@bag_path, 'data', f))).should be_true
+        File.dirname(File.join(@bag_path, 'data', f)).should exist_on_fs
         @bag.gc!
-        File.exist?(File.dirname(File.join(@bag_path, 'data', f))).should be_false
+        File.dirname(File.join(@bag_path, 'data', f)).should_not exist_on_fs
       end
     end
   end

--- a/spec/fetch_spec.rb
+++ b/spec/fetch_spec.rb
@@ -53,7 +53,7 @@ describe "fetch.txt" do
     data.should_not include('gnu2.png')
   end
 
-  it "should actually contained manifested files after fetch" do
+  it "should actually contain manifested files after fetch" do
     @bag.fetch!
     good_path = File.join @bag_path, 'data', 'gnu.png'
     File.exist?(good_path).should be_true

--- a/spec/fetch_spec.rb
+++ b/spec/fetch_spec.rb
@@ -26,7 +26,10 @@ describe "fetch.txt" do
   end
 
   before(:each) do
-    @bag.add_remote_file('http://www.gnu.org/graphics/heckert_gnu.small.png', 'gnu.png', 6322,
+    @bag.add_remote_file('http://www.gnu.org/graphics/heckert_gnu.small.png', 'data/gnu.png', 6322,
+                         '390c0a30976f899cbdf951eab5cce60fe9743ac9',
+                         'a3bd7ab2442028bb91b51d9f6722ec98')
+    @bag.add_remote_file('http://www.gnu.org/graphics/heckert_gnu.small.png', 'gnu2.png', 6322,
                          '390c0a30976f899cbdf951eab5cce60fe9743ac9',
                          'a3bd7ab2442028bb91b51d9f6722ec98')
 
@@ -45,7 +48,14 @@ describe "fetch.txt" do
   it "should contain manifested files" do
     path = File.join @bag_path, 'manifest-sha1.txt'
     data = File.open(path) { |io| io.read }
-    data.should include('gnu.png')
+    data.should include('data/gnu.png')
+    data.should_not include('data/data/gnu.png')
+  end
+
+  it "should not contain stray non-payload files" do
+    path = File.join @bag_path, 'manifest-sha1.txt'
+    data = File.open(path) { |io| io.read }
+    data.should_not include('gnu2.png')
   end
 
   it "should be gone when fetch is complete" do

--- a/spec/fetch_spec.rb
+++ b/spec/fetch_spec.rb
@@ -55,15 +55,13 @@ describe "fetch.txt" do
 
   it "should actually contain manifested files after fetch" do
     @bag.fetch!
-    good_path = File.join @bag_path, 'data', 'gnu.png'
-    File.exist?(good_path).should be_true
-    bad_path = File.join @bag_path, 'gnu2.png'
-    File.exist?(bad_path).should be_false
+    File.join(@bag_path, "data", "gnu.png").should exist_on_fs
+    File.join(@bag_path, "gnu2.png").should_not exist_on_fs
   end
 
   it "should be gone when fetch is complete" do
     @bag.fetch!
-    File.exist?(File.join(@bag_path, 'fetch.txt')).should_not be_true
+    File.join(@bag_path, "fetch.txt").should_not exist_on_fs
   end
 
 end

--- a/spec/fetch_spec.rb
+++ b/spec/fetch_spec.rb
@@ -45,17 +45,20 @@ describe "fetch.txt" do
     @lines.each { |line| line.chomp.should =~ /^[^\s]+\s+(\d+|\-)\s+[^\s]+$/ }
   end
 
-  it "should contain manifested files" do
+  it "should list fetched files in the manifest" do
     path = File.join @bag_path, 'manifest-sha1.txt'
     data = File.open(path) { |io| io.read }
     data.should include('data/gnu.png')
     data.should_not include('data/data/gnu.png')
+    data.should_not include('gnu2.png')
   end
 
-  it "should not contain stray non-payload files" do
-    path = File.join @bag_path, 'manifest-sha1.txt'
-    data = File.open(path) { |io| io.read }
-    data.should_not include('gnu2.png')
+  it "should actually contained manifested files after fetch" do
+    @bag.fetch!
+    good_path = File.join @bag_path, 'data', 'gnu.png'
+    File.exist?(good_path).should be_true
+    bad_path = File.join @bag_path, 'gnu2.png'
+    File.exist?(bad_path).should be_false
   end
 
   it "should be gone when fetch is complete" do

--- a/spec/util/bagit_matchers.rb
+++ b/spec/util/bagit_matchers.rb
@@ -15,7 +15,7 @@ module BagitMatchers
       "expected <#{@target}> to be in collection <#{@expected}>"
     end
 
-    def negative_failure_message
+    def failure_message_when_negated
       "expected <#{@target}> to not be in collection <#{@expected}>"
     end
 
@@ -36,7 +36,7 @@ module BagitMatchers
       "expected <#{@target}> to exist, but it doesn't"
     end
 
-    def negative_failure_message
+    def failure_message_when_negated
       "expected <#{@target}> to not exist but it does"
     end
 
@@ -44,6 +44,27 @@ module BagitMatchers
 
   def exist_on_fs
     ExistOnFS.new
+  end
+
+  class BeADirectory
+
+    def matches?(target)
+      @target = target
+      File.directory? target
+    end
+
+    def failure_message
+      "expected <#{@target}> to be a directory, but it isn't"
+    end
+
+    def failure_message_when_negated
+      "expected <#{@target}> not to be a directory, but it is"
+    end
+
+  end
+
+  def be_a_directory
+    BeADirectory.new
   end
 
 end


### PR DESCRIPTION
This modifies BagIt::Fetch#remote_add_file to address @hading's bug report (#12).  Moreover, only valid payload paths (those starting with "data/") are included in fetch.txt or fetched.