### PR TITLE
Handle unknown algorithm

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ Bundler::GemHelper.install_tasks
 
 RSpec::Core::RakeTask.new do |t|
   t.pattern = 'spec/**/*_spec.rb'
-  t.rspec_opts = %w(-fs --color)
+  # t.rspec_opts = %w(-fs --color)
 end
 
 task :default => [:spec]

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'bundler/setup'
 Bundler.setup(:default, :development, :test)
 
 require 'rake'
-require 'rdoc/task'
+# require 'rdoc/task'
 require 'rspec/core/rake_task'
 
 Bundler::GemHelper.install_tasks

--- a/bagit.gemspec
+++ b/bagit.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'byebug'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/bagit.gemspec
+++ b/bagit.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'byebug'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/bagit/valid.rb
+++ b/lib/bagit/valid.rb
@@ -33,13 +33,14 @@ module BagIt
       (manifest_files|tagmanifest_files).each do |mf|
         # get the algorithm implementation
         File.basename(mf) =~ /manifest-(.+).txt$/
-        algo = case $1
+        manifest_type = $1
+        algo = case manifest_type
                when /sha1/i
                  Digest::SHA1
                when /md5/i
                  Digest::MD5
                else
-                 :unknown
+                 raise ArgumentError.new("Algorithm #{manifest_type} is not supported.")
                end
         # Check every file in the manifest
         File.open(mf) do |io|

--- a/spec/bagit_spec.rb
+++ b/spec/bagit_spec.rb
@@ -41,7 +41,7 @@ describe BagIt::Bag do
     end
 
     it "should be a directory" do
-      File.directory?(@bag_path).should be_true
+      expect(File.directory?(@bag_path)).to be true
     end
 
     it "should not be empty" do
@@ -50,7 +50,7 @@ describe BagIt::Bag do
 
     it "should have a sub-directory called data" do
       data_path = File.join @bag_path, 'data'
-      File.directory?(data_path).should be_true
+      expect(File.directory?(data_path)).to be true
     end
 
     describe "#add_file" do
@@ -149,11 +149,12 @@ describe BagIt::Bag do
     describe "#gc!" do
       it "should clean up empty directories" do
         f = File.join "1", "2", "3", "file"
+        test_dir = File.dirname(File.join(@bag_path, 'data', f))
         @bag.add_file(f) { |io| io.puts 'all alone' }
         @bag.remove_file f
-        File.exist?(File.dirname(File.join(@bag_path, 'data', f))).should be_true
+        expect(File.exist?(test_dir)).to be true
         @bag.gc!
-        File.exist?(File.dirname(File.join(@bag_path, 'data', f))).should be_false
+        expect(File.exist?(test_dir)).to be false
       end
     end
   end

--- a/spec/fetch_spec.rb
+++ b/spec/fetch_spec.rb
@@ -50,7 +50,8 @@ describe "fetch.txt" do
 
   it "should be gone when fetch is complete" do
     @bag.fetch!
-    File.exist?(File.join(@bag_path, 'fetch.txt')).should_not be_true
+    fetch_txt = File.join(@bag_path, 'fetch.txt')
+    expect(File.exist?(fetch_txt)).to be false
   end
 
 end

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -82,6 +82,14 @@ describe "a valid bag" do
     expected.should == '12be64c30968bb90136ee695dc58f4b2276968c6'
   end
 
+  it "should raise an sensible error when the manifest algorithm is unknown" do
+    # add a manifest with an unsupported algorithm
+    File.open(File.join(@bag.bag_dir, 'manifest-sha256.txt'), 'w') do |io|
+      io.puts "digest-does-not-matter data/file-0\n"
+    end
+    expect { @bag.valid? }.to raise_error ArgumentError
+  end
+
   it "should validate by oxum when needed" do
     @bag.valid_oxum?.should == true
   end


### PR DESCRIPTION
This PR raises an exception with a sensible error message when attempting to validate a bag that has an algorithm type that the gem does not support (e.g. sha-256)

The current implementation throws a rather confusing ":unknown:Symbol" error when this situation arises because when line `actual = algo.file(file).hexdigest` is executed `algo` is `:unknown` rather than an valid Digest class. The PR makes the error more obvious (Algorithm XYZ is not supported).
