### PR TITLE
Remove Windows carriage return from Specs

### DIFF
--- a/spec/fetch_spec.rb
+++ b/spec/fetch_spec.rb
@@ -15,7 +15,7 @@ describe "fetch.txt" do
     File.open('/dev/urandom') do |rio|
 
       10.times do |n|
-        @bag.add_file("file-#{n}-💩") { |io| io.write rio.read(16) }
+        @bag.add_file("file-#{n}-💩") { |io| io.write rio.read(16) }
       end
 
     end

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -15,13 +15,13 @@ describe "BagIt Manifests" do
     File.open('/dev/urandom') do |rio|
 
       10.times do |n|
-        @bag.add_file("file-#{n}-💩") { |io| io.write rio.read(16) }
+        @bag.add_file("file-#{n}-💩") { |io| io.write rio.read(16) }
         @bag.add_tag_file("tag-#{n}") { |io| io.write rio.read(16) }
       end
 
-      
-     
-      
+
+
+
     end
 
   end

--- a/spec/tag_info_spec.rb
+++ b/spec/tag_info_spec.rb
@@ -14,7 +14,7 @@ describe "Tag Info Files" do
     # add some files
     File.open('/dev/urandom') do |rio|
       10.times do |n|
-        @bag.add_file("file-#{n}-💩") { |io| io.write rio.read(16) }
+        @bag.add_file("file-#{n}-💩") { |io| io.write rio.read(16) }
       end
     end
 

--- a/spec/tag_spec.rb
+++ b/spec/tag_spec.rb
@@ -15,7 +15,7 @@ describe "Tag Specs" do
     File.open('/dev/urandom') do |rio|
 
       10.times do |n|
-        @bag.add_file("file-#{n}-💩") { |io| io.write rio.read(16) }
+        @bag.add_file("file-#{n}-💩") { |io| io.write rio.read(16) }
         @bag.add_tag_file("tag-#{n}") { |io| io.write rio.read(16)}
       end
 


### PR DESCRIPTION
Ahoy hoy.

Thanks to all the contributors for this wonderful gem.
When running rspec I noticed output like:

```
$ rspec
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
/my/path/to/bagit/spec/fetch_spec.rb:18: warning: encountered \r in middle of line, treated as a mere space
/my/path/to/bagit/spec/manifest_spec.rb:18: warning: encountered \r in middle of line, treated as a mere space
/my/path/to/bagit/spec/tag_info_spec.rb:17: warning: encountered \r in middle of line, treated as a mere space
/my/path/to/bagit/spec/tag_spec.rb:18: warning: encountered \r in middle of line, treated as a mere space
..............................................................
SNIP!
```

This PR removes the warning without altering the implementation of any of the specs.
Thanks again for the gem.