### PR TITLE
Fixes Issue Where 'validate' CLI can only validate md5 and sha1

### DIFF
--- a/bin/bagit
+++ b/bin/bagit
@@ -48,16 +48,18 @@ begin
   # commands that don't alter the bag #
   #####################################
   if opts['validate']
-    if File.exists?(opts['BAGPATH']+'/bag-info.txt') && File.directory?(opts['BAGPATH']+'/data') && File.exists?(opts['BAGPATH']+'/manifest-md5.txt') || File.exists?(opts['BAGPATH']+'/manifest-sha1.txt')
-      bag = BagIt::Bag.new(opts['BAGPATH'])
-      if opts['--oxum']
-        logger.info(bag.valid_oxum?.to_s)
-      else
-        logger.info(bag.valid?.to_s)
-      end
+    bag = BagIt::Bag.new(opts['BAGPATH'])
+
+    if opts['--oxum']
+      valid = bag.valid_oxum?
     else
-      logger.error("Not a valid bag")
+      valid = bag.valid?
     end
+
+    if valid
+      logger.info(valid)
+    end
+
     # validation commands MUST NOT change manifest or bag-info files
     exit
   end

--- a/bin/bagit
+++ b/bin/bagit
@@ -58,6 +58,8 @@ begin
 
     if valid
       logger.info(valid)
+    else
+      logger.error("#{valid}: #{bag.errors.full_messages.join(', ')}" )
     end
 
     # validation commands MUST NOT change manifest or bag-info files

--- a/lib/bagit/version.rb
+++ b/lib/bagit/version.rb
@@ -1,3 +1,3 @@
 module BagIt
-  VERSION = "0.3.5"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
Currently - the validate cli [does some pre-flight checking](https://github.com/tipr/bagit/blob/d17133b/bin/bagit#L51) that will falsely return "not a valid bag" if the manifest is something other than md5 or sha1.

The Bag class does a good job of validating, and logging any errors already.
I did a version bump since the output _could_ be different and I want to be upfront that
if anyone is shelling out to `bagit validate` then the output could be different.

Here's a few example runs:

### Against A Perfect sha512 manifested bag

```
$ bagit validate ~/Desktop/gigantic_bag

I, [2016-12-14T15:10:35.226085 #87202]  INFO -- : true
```

### Against A Bag with corrupted files

```
$ bagit validate ~/Desktop/gigantic_bag

E, [2016-12-14T15:24:12.065865 #88549] ERROR -- : false: Consistency expected /Users/sschor/Desktop/gigantic_bag/data/lorem_1.txt to have Digest::SHA512: x969d110708b17873e9e6ca7ee4aef8baabbec765df80af88b9d6ec11711810bf6ce460610fbe4694c5a7f5808c284e8cacee9d3e12bf9bc4f76ec1329e5e45d, actual is 2969d110708b17873e9e6ca7ee4aef8baabbec765df80af88b9d6ec11711810bf6ce460610fbe4694c5a7f5808c284e8cacee9d3e12bf9bc4f76ec1329e5e45d, Consistency expected /Users/sschor/Desktop/gigantic_bag/data/video_1.mov to have Digest::SHA512: x0d70bc663de5afda6b1e95634115b8e81a63acbccb58a3530e5ad92fc0d25c2dc0b3d77c9009813c15d11453b17cea93980e8a8a3a64681a33f48706bbb56f1, actual is f0d70bc663de5afda6b1e95634115b8e81a63acbccb58a3530e5ad92fc0d25c2dc0b3d77c9009813c15d11453b17cea93980e8a8a3a64681a33f48706bbb56f1, Consistency expected /Users/sschor/Desktop/gigantic_bag/data/urand.data to have Digest::SHA512: x4f857fe404d2858140edfe74f1a45d93604e4884494b4a9d9c4851ba7dd11b1814020de8c2f169fd01d3dfcc57bd422e75794b5cc69236e75c42c84e7f7c911, actual is 64f857fe404d2858140edfe74f1a45d93604e4884494b4a9d9c4851ba7dd11b1814020de8c2f169fd01d3dfcc57bd422e75794b5cc69236e75c42c84e7f7c911, Consistency expected /Users/sschor/Desktop/gigantic_bag/manifest-sha512.txt to have Digest::SHA512: aa4d37c0708df182485ba7cc97732e24e898ee166aa73f79e2cb44232c7b55858852dd83a34322db02b9e8c05571f8de819dd39775f72062bf21e20891075ea3, actual is 234ba48d097666b1c56f2061a38908007f5354d3377dfd0edb2cec50698716972ffd34ee01553dcb8ab6ffe6331bc1d308388efb11d660bcc8ff9a20898e6c81, Consistency is invalid
```

### With a manifest named 'manifest-sha51333.txt'

```
$ bagit validate ~/Desktop/gigantic_bag
/Users/sschor/.rvm/gems/ruby-2.3.0/gems/bagit-0.3.5/lib/bagit/valid.rb:65:in `block in consistent?': Algorithm sha51333 is not supported. (ArgumentError)
	from /Users/sschor/.rvm/gems/ruby-2.3.0/gems/bagit-0.3.5/lib/bagit/valid.rb:49:in `each'
...SNIP!
```
