### PR TITLE
Allow for setting the hashing algorithm

### DIFF
--- a/bagit.gemspec
+++ b/bagit.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license     = "MIT"
 
   spec.required_ruby_version = '~> 2.0'
-  
+
   spec.add_dependency 'validatable', '~> 1.6'
   spec.add_dependency 'docopt', '~> 0.5.0'
 
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.4'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/bin/bagit
+++ b/bin/bagit
@@ -3,22 +3,23 @@
 require 'bagit'
 require 'docopt'
 require 'logger'
-
+require 'pry'
 logger = Logger.new(STDOUT)
 
 doc = <<DOCOPT
 BagIt.
 
-Usage: 
-  bagit add [-f <file>...] [-t <tagfile>...] BAGPATH
+Usage:
+  bagit add [-f <file>...] [-t <tagfile>...] [-a <algo>] BAGPATH
   bagit delete [-f <file>...] [-t <tagfile>...] BAGPATH
   bagit remove [-t <tagfile>...] BAGPATH
-  bagit validate [-o] BAGPATH 
+  bagit validate [-o] BAGPATH
   bagit manifest [-T] BAGPATH
-  bagit list [--tags | --all] BAGPATH 
+  bagit list [--tags | --all] BAGPATH
   bagit -h | --version
 
 Options:
+  -a             A selected hashing algorithm. (md5, sha1, sha256)
   -h --help      Show this help screen.
   --version      Show version.
   -f <file>      File to add to/delete from bag. Repeatable.
@@ -31,11 +32,11 @@ Options:
 DOCOPT
 
   # Possible commands for bag-info write
-  # 
-  # bagit new [--source-organization <org>] [--organization-address <org-addr>] [--contact-name <contact>] 
-  #             [--contact-phone <phone>] [--contact-email <email>] [--external-description <ext-desc>] 
-  #             [--external-identifier <ext-id>] [--group-identifier <group-id>] [--count <count>] 
-  #             [--internal-sender-identifier <sender-id>] [--internal-sender-description <sender-desc>] 
+  #
+  # bagit new [--source-organization <org>] [--organization-address <org-addr>] [--contact-name <contact>]
+  #             [--contact-phone <phone>] [--contact-email <email>] [--external-description <ext-desc>]
+  #             [--external-identifier <ext-id>] [--group-identifier <group-id>] [--count <count>]
+  #             [--internal-sender-identifier <sender-id>] [--internal-sender-description <sender-desc>]
   #             [--bag-info-entry <label> <value>] [-f <file>...] [-t <tagfile>...] BAGPATH
 
 begin
@@ -86,7 +87,7 @@ begin
   #TODO: implement delete for data and tag files; remove for tag files.
 
   # handle add/delete bag data files
-  unless opts['-f'].nil? 
+  unless opts['-f'].nil?
     #TODO: add files in nested directories
     opts['-f'].each { |datafile|
       begin
@@ -98,11 +99,11 @@ begin
       rescue Exception => e
         logger.error("Failed operation on bag file: #{e.message}")
       end
-    }  
+    }
   end
 
   # handle adding tag files
-  unless opts['-t'].nil? 
+  unless opts['-t'].nil?
     #TODO: add files in nested directories
     opts['-t'].each { |tagfile|
       begin
@@ -126,11 +127,15 @@ begin
   end
 
   # if we haven't quit yet, we need to re-manifest
-  # only do tags if tag files have been explictly added/removed or it is explictly called 
+  # only do tags if tag files have been explictly added/removed or it is explictly called
   bag.tagmanifest! if opts['-T'] or not opts['-t'].nil?
-  bag.manifest!
+
+  unless opts['-a'].nil?
+    bag.manifest!(algo: opts['<algo>'])
+  else
+    bag.manifest!
+  end
 
 rescue Docopt::Exit => e
   logger.error(e.message.red)
 end
-

--- a/lib/bagit/manifest.rb
+++ b/lib/bagit/manifest.rb
@@ -12,7 +12,7 @@ module BagIt
      return s
     end
 
-  
+
     # All tag files that are bag manifest files (manifest-[algorithm].txt)
     def manifest_files
       files = Dir[File.join(@bag_dir, '*')].select { |f|
@@ -27,7 +27,7 @@ module BagIt
     end
 
     # Generate manifest files for all the bag files
-    def manifest!
+    def manifest!(algo: 'default')
 
       # nuke all the existing manifest files
       manifest_files.each { |f| FileUtils::rm f }
@@ -35,16 +35,42 @@ module BagIt
       # manifest each tag file for each algorithm
       bag_files.each do |f|
         rel_path = encode_filename(Pathname.new(f).relative_path_from(Pathname.new(bag_dir)).to_s)
-        
-        # sha1
-        sha1 = Digest::SHA1.file f
-        File.open(manifest_file(:sha1), 'a') { |io| io.puts "#{sha1} #{rel_path}" }
 
-        # md5
-        md5 = Digest::MD5.file f
-        File.open(manifest_file(:md5), 'a') { |io| io.puts "#{md5} #{rel_path}" }
+        case algo
+        when 'sha1'
+          write_sha1(f, rel_path)
+        when 'md5'
+          write_md5(f, rel_path)
+        when 'sha256'
+          write_sha256(f, rel_path)
+        when 'sha512'
+          write_sha256(f, rel_path)
+        when 'default'
+          write_sha1(f, rel_path)
+          write_md5(f, rel_path)
+        end
       end
       tagmanifest!
+    end
+
+    def write_sha1(f, rel_path)
+      sha1 = Digest::SHA1.file f
+      File.open(manifest_file(:sha1), 'a') { |io| io.puts "#{sha1} #{rel_path}" }
+    end
+
+    def write_md5(f, rel_path)
+      md5 = Digest::MD5.file f
+      File.open(manifest_file(:md5), 'a') { |io| io.puts "#{md5} #{rel_path}" }
+    end
+
+    def write_sha256(f, rel_path)
+      sha256 = Digest::SHA256.file f
+      File.open(manifest_file(:sha256), 'a') { |io| io.puts "#{sha256} #{rel_path}" }
+    end
+
+    def write_sha512(f, rel_path)
+      sha512 = Digest::SHA512.file f
+      File.open(manifest_file(:sha512), 'a') { |io| io.puts "#{sha512} #{rel_path}" }
     end
 
     # All tag files that are bag manifest files (tagmanifest-[algorithm].txt)

--- a/lib/bagit/version.rb
+++ b/lib/bagit/version.rb
@@ -1,3 +1,3 @@
 module BagIt
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
This change allows the `manifest!` method to accept and
`algo:` paramter that indicates what kind of hashing algorithm
you want to use for the bag. If that paramter is not supplied
it uses md5 and sha1.

You can choose from md5, sha1, and sha256.

From the command line you can supply the hashing algo as well:

```sh
bagit add -f LICENSE.txt -a 'sha256' test
```