### PR TITLE
Don't require `pry`, which is not a production dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'bundler/setup'
 Bundler.setup(:default, :development, :test)

--- a/bagit.gemspec
+++ b/bagit.gemspec
@@ -1,4 +1,6 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'bagit/version'

--- a/bin/bagit
+++ b/bin/bagit
@@ -4,7 +4,6 @@
 require 'bagit'
 require 'docopt'
 require 'logger'
-require 'pry'
 logger = Logger.new(STDOUT)
 
 doc = <<DOCOPT

--- a/bin/bagit
+++ b/bin/bagit
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bagit'
 require 'docopt'
@@ -84,42 +85,36 @@ begin
   # TODO: implement delete for data and tag files; remove for tag files.
 
   # handle add/delete bag data files
-  unless opts['-f'].nil?
-    # TODO: add files in nested directories
-    opts['-f'].each do |datafile|
-      begin
-        if opts['add'] || opts['new']
-          bag.add_file(File.basename(datafile), datafile)
-        elsif opts['delete']
-          bag.remove_file(File.basename(datafile))
-        end
-      rescue StandardError => e
-        logger.error("Failed operation on bag file: #{e.message}")
+  opts['-f']&.each do |datafile|
+    begin
+      if opts['add'] || opts['new']
+        bag.add_file(File.basename(datafile), datafile)
+      elsif opts['delete']
+        bag.remove_file(File.basename(datafile))
       end
+    rescue StandardError => e
+      logger.error("Failed operation on bag file: #{e.message}")
     end
   end
 
   # handle adding tag files
-  unless opts['-t'].nil?
-    # TODO: add files in nested directories
-    opts['-t'].each do |tagfile|
-      begin
-        if opts['add'] || opts['new']
-          # if it does, try to manifest it
-          if File.exist?(File.join(bag.bag_dir, File.basename(tagfile)))
-            bag.add_tag_file(tagfile)
-            # otherwise, add it
-          else
-            bag.add_tag_file(File.basename(tagfile), tagfile)
-          end
-        elsif opts['delete']
-          bag.delete_tag_file(File.basename(tagfile))
-        elsif opts['remove']
-          bag.remove_tag_file(File.basename(tagfile))
+  opts['-t']&.each do |tagfile|
+    begin
+      if opts['add'] || opts['new']
+        # if it does, try to manifest it
+        if File.exist?(File.join(bag.bag_dir, File.basename(tagfile)))
+          bag.add_tag_file(tagfile)
+          # otherwise, add it
+        else
+          bag.add_tag_file(File.basename(tagfile), tagfile)
         end
-      rescue StandardError => e
-        logger.error("Failed operation on tag file: #{e.message}".red)
+      elsif opts['delete']
+        bag.delete_tag_file(File.basename(tagfile))
+      elsif opts['remove']
+        bag.remove_tag_file(File.basename(tagfile))
       end
+    rescue StandardError => e
+      logger.error("Failed operation on tag file: #{e.message}".red)
     end
   end
 

--- a/lib/bagit.rb
+++ b/lib/bagit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == About bagit.rb
 # Author::    Francesco Lazzarino  (mailto:flazzarino@gmail.com)
 # Functionality conforms to the BagIt Spec v0.96:
@@ -10,5 +12,5 @@ require 'date'
 require 'logger'
 module BagIt
   # The version of the BagIt specification the code is conforming to.
-  SPEC_VERSION = '0.97'.freeze
+  SPEC_VERSION = '0.97'
 end

--- a/lib/bagit/bag.rb
+++ b/lib/bagit/bag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bagit/fetch'
 require 'bagit/file'
 require 'bagit/info'

--- a/lib/bagit/fetch.rb
+++ b/lib/bagit/fetch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open-uri'
 
 module BagIt
@@ -29,7 +31,7 @@ module BagIt
     end
 
     def rename_old_fetch_txt(fetch_txt_file)
-      Dir["#{fetch_txt_file}.?*"].sort.reverse.each do |f|
+      Dir["#{fetch_txt_file}.?*"].sort.reverse_each do |f|
         if f =~ /fetch.txt.(\d+)$/
           new_f = File.join File.dirname(f), "fetch.txt.#{Regexp.last_match(1).to_i + 1}"
           FileUtils.mv f, new_f

--- a/lib/bagit/file.rb
+++ b/lib/bagit/file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class File
   # Clean out all the empty dirs
   def self.clean(file_name)

--- a/lib/bagit/info.rb
+++ b/lib/bagit/info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module BagIt

--- a/lib/bagit/manifest.rb
+++ b/lib/bagit/manifest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'digest/sha1'
 require 'digest/md5'

--- a/lib/bagit/string.rb
+++ b/lib/bagit/string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Some mixed in functionality for String
 class String
   # Wrap a string to lines of a specified width. All existing newlines

--- a/lib/bagit/valid.rb
+++ b/lib/bagit/valid.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'validatable'
 require 'open-uri'
 require 'cgi'

--- a/lib/bagit/version.rb
+++ b/lib/bagit/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BagIt
-  VERSION = "0.4.3".freeze
+  VERSION = "0.4.3"
 end

--- a/spec/bagit_spec.rb
+++ b/spec/bagit_spec.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 # based on v0.96 http://www.cdlib.org/inside/diglib/bagit/bagitspec.html

--- a/spec/fetch_spec.rb
+++ b/spec/fetch_spec.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe BagIt::Bag do

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe BagIt::Bag do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'bundler'
 require 'coveralls'

--- a/spec/tag_info_spec.rb
+++ b/spec/tag_info_spec.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe BagIt::Bag do

--- a/spec/tag_spec.rb
+++ b/spec/tag_spec.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe BagIt::Bag do

--- a/spec/util/bagit_matchers.rb
+++ b/spec/util/bagit_matchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BagitMatchers
   class BeIn
     def initialize(*expected_collection)

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe BagIt::Bag do


### PR DESCRIPTION
Inclusion of this `require` breaks the CLI for all systems that don't have `pry`
installed.