### PR TITLE
Allow ruby 3.2

### DIFF
--- a/bagit.gemspec
+++ b/bagit.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Tom Johnson, Francesco Lazzarino, Jamie Little"]
   spec.license = "MIT"
 
-  spec.required_ruby_version = ">= 2.0", "< 3.2"
+  spec.required_ruby_version = ">= 2.0", "< 3.3"
 
   spec.add_dependency "validatable", "~> 1.6"
   spec.add_dependency "docopt", "~> 0.5.0"

--- a/lib/bagit/version.rb
+++ b/lib/bagit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BagIt
-  VERSION = "0.4.5"
+  VERSION = "0.4.6"
 end


### PR DESCRIPTION
Or is there a reason to not support it? 
Specs seem to run. 