### PR TITLE
Allow Ruby 3.3

### DIFF
--- a/bagit.gemspec
+++ b/bagit.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Tom Johnson, Francesco Lazzarino, Jamie Little"]
   spec.license = "MIT"
 
-  spec.required_ruby_version = ">= 2.0", "< 3.3"
+  spec.required_ruby_version = ">= 2.0", "< 3.4"
 
   spec.add_dependency "validatable", "~> 1.6"
   spec.add_dependency "docopt", "~> 0.5.0"

--- a/lib/bagit/version.rb
+++ b/lib/bagit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BagIt
-  VERSION = "0.4.6"
+  VERSION = "0.4.7"
 end


### PR DESCRIPTION
Similar to #48, specs run fine on Ruby 3.3.x.