### PR TITLE
Ruby 4 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,8 @@
 source "https://rubygems.org"
 
 gemspec
+
+group :development do
+  gem "rdoc"
+end
+

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,3 @@ gemspec
 group :development do
   gem "rdoc"
 end
-

--- a/bagit.gemspec
+++ b/bagit.gemspec
@@ -30,6 +30,5 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 end

--- a/bagit.gemspec
+++ b/bagit.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "validatable", "~> 1.6"
   spec.add_dependency "docopt", "~> 0.5.0"
+  spec.add_dependency "logger", "~> 1.7"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "coveralls"

--- a/bagit.gemspec
+++ b/bagit.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Tom Johnson, Francesco Lazzarino, Jamie Little"]
   spec.license = "MIT"
 
-  spec.required_ruby_version = ">= 2.0", "< 3.5"
+  spec.required_ruby_version = ">= 2.0", "< 4.1"
 
   spec.add_dependency "validatable", "~> 1.6"
   spec.add_dependency "docopt", "~> 0.5.0"

--- a/lib/bagit/fetch.rb
+++ b/lib/bagit/fetch.rb
@@ -21,7 +21,7 @@ module BagIt
           (url, _length, path) = line.chomp.split(/\s+/, 3)
 
           add_file(path) do |file_io|
-            file_io.write URI.open(url)
+            file_io.write URI.parse(url).open
           end
         end
       end

--- a/lib/bagit/info.rb
+++ b/lib/bagit/info.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
-
 module BagIt
   module Info
     @@bag_info_headers = {
@@ -73,7 +71,7 @@ module BagIt
     def write_info_file(file, hash)
       dups = hash.keys.inject(Set.new) { |acc, key|
         a = hash.keys.grep(/#{key}/i)
-        acc + (a.size > 1 ? a : [])
+        acc + ((a.size > 1) ? a : [])
       }
 
       raise "Multiple labels (#{dups.to_a.join ", "}) in #{file}" unless dups.empty?

--- a/lib/bagit/manifest.rb
+++ b/lib/bagit/manifest.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "pathname"
 require "digest/sha1"
 require "digest/md5"
 
@@ -8,17 +7,15 @@ module BagIt
   # Requires response to bag_dir, tag_files, bag_files
   module Manifest
     def encode_filename(s)
-      s = s.gsub(/\r/, "%0D")
-      s = s.gsub(/\n/, "%0A")
-      s
+      s = s.gsub("\r", "%0D")
+      s.gsub("\n", "%0A")
     end
 
     # All tag files that are bag manifest files (manifest-[algorithm].txt)
     def manifest_files
-      files = Dir[File.join(@bag_dir, "*")].select { |f|
+      Dir[File.join(@bag_dir, "*")].select { |f|
         File.file?(f) && File.basename(f) =~ /^manifest-.*.txt$/
       }
-      files
     end
 
     # A path to a manifest file of the specified algorithm
@@ -78,10 +75,9 @@ module BagIt
 
     # All tag files that are bag manifest files (tagmanifest-[algorithm].txt)
     def tagmanifest_files
-      files = Dir[File.join(@bag_dir, "*")].select { |f|
+      Dir[File.join(@bag_dir, "*")].select { |f|
         File.file?(f) && File.basename(f) =~ /^tagmanifest-.*.txt$/
       }
-      files
     end
 
     # A path to a tagmanifest file of the specified algorithm
@@ -134,7 +130,7 @@ module BagIt
         raise "Tag file already exists, will not overwrite: #{path}\n Use add_tag_file(path) to add an existing tag file."
       end
 
-      data = File.open(f, &:read)
+      data = File.read(f)
       rel_path = Pathname.new(f).relative_path_from(Pathname.new(bag_dir)).to_s
 
       # sha1
@@ -169,12 +165,12 @@ module BagIt
         mf =~ /manifest-(.+).txt$/
 
         algo = case Regexp.last_match(1)
-               when /sha1/i
-                 Digest::SHA1
-               when /md5/i
-                 Digest::MD5
-               else
-                 :unknown
+        when /sha1/i
+          Digest::SHA1
+        when /md5/i
+          Digest::MD5
+        else
+          :unknown
         end
 
         # check it, an unknown algorithm is always true

--- a/lib/bagit/string.rb
+++ b/lib/bagit/string.rb
@@ -8,7 +8,7 @@ class String
     s = gsub(/\s+/, " ").strip
 
     if s.length > width
-      s[0...width] + '\n' + s[width..-1].wrap(width)
+      s[0...width] + '\n' + s[width..].wrap(width)
     else
       s
     end

--- a/lib/bagit/valid.rb
+++ b/lib/bagit/valid.rb
@@ -8,6 +8,7 @@ require "logger"
 module BagIt
   class Bag
     include Validatable
+
     validates_true_for :consistency, logic: proc { consistent? }
     validates_true_for :completeness, logic: proc { complete? }
   end
@@ -15,14 +16,13 @@ module BagIt
   module Validity
     def decode_filename(s)
       s = s.gsub("%0D", "\r")
-      s = s.gsub("%0A", "\n")
-      s
+      s.gsub("%0A", "\n")
     end
 
     # Return true if the manifest cover all files and all files are
     # covered.
     def complete?
-      logger = Logger.new(STDOUT)
+      logger = Logger.new($stdout)
 
       errors.add :completeness, "there are no manifest files" if manifest_files == []
 

--- a/spec/fetch_spec.rb
+++ b/spec/fetch_spec.rb
@@ -40,7 +40,7 @@ describe BagIt::Bag do
 
     it "contains manifested files" do
       path = File.join @bag_path, "manifest-sha1.txt"
-      data = File.open(path, &:read)
+      data = File.read(path)
       expect(data).to include("gnu.png")
     end
 

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -101,10 +101,10 @@ describe BagIt::Bag do
       end
       it "contains manifest and bag info files" do
         @bag.tagmanifest_files.each do |mf|
-          expect(File.open(mf).read).to include(File.basename(@bag.bag_info_txt_file))
-          expect(File.open(mf).read).to include(File.basename(@bag.bagit_txt_file))
+          expect(File.read(mf)).to include(File.basename(@bag.bag_info_txt_file))
+          expect(File.read(mf)).to include(File.basename(@bag.bagit_txt_file))
           @bag.manifest_files.each do |man|
-            expect(File.open(mf).read).to include(man)
+            expect(File.read(mf)).to include(man)
           end
         end
       end

--- a/spec/tag_info_spec.rb
+++ b/spec/tag_info_spec.rb
@@ -98,7 +98,7 @@ describe BagIt::Bag do
         @bag.write_bag_info "Source-Organization" => "Awesome Inc."
         @bag.write_bag_info "Bagging-Date" => "1901-01-01"
         @bag.write_bag_info
-        contents = File.open(path).read
+        contents = File.read(path)
         expect(contents).to include "Some Other Agent"
         expect(contents).to include "Awesome Inc."
         expect(contents).to include "1901-01-01"
@@ -107,7 +107,7 @@ describe BagIt::Bag do
         path = File.join @bag_path, "bag-info.txt"
         @bag.write_bag_info "Source-Organization" => "Awesome Inc."
         @bag.write_bag_info "Source-Organization" => "Awesome LLC."
-        contents = File.open(path).read
+        contents = File.read(path)
         expect(contents).to include "Awesome LLC."
         expect(contents).not_to include "Awesome Inc."
       end

--- a/spec/util/bagit_matchers.rb
+++ b/spec/util/bagit_matchers.rb
@@ -18,7 +18,7 @@ module BagitMatchers
     def failure_message_when_negated
       "expected <#{@target}> to not be in collection <#{@expected}>"
     end
-    alias negative_failure_message failure_message_when_negated
+    alias_method :negative_failure_message, :failure_message_when_negated
   end
 
   def be_in(*expected_collection)
@@ -38,7 +38,7 @@ module BagitMatchers
     def failure_message_when_negated
       "expected <#{@target}> to not exist but it does"
     end
-    alias negative_failure_message failure_message_when_negated
+    alias_method :negative_failure_message, :failure_message_when_negated
   end
 
   def exist_on_fs


### PR DESCRIPTION
- Expands `spec.required_ruby_version` to include 4.0
- Adds necessary gems no longer available by default in Ruby 3.5 / 4+:
  - `rdoc` -- added directly to the Gemfile, since it's only needed in the Rakefile
  - `logger` -- added in the gemspec, since users of the gem will also need it
- Fixes style problems identified by `standardrb`

**Note:** I ran the tests under Ruby 2.7 and Ruby 4.0.3, but not anything earlier, and not anything in between. It might be worth considering updating the `required_ruby_version` lower bound to 2.7 -- I can't guarantee all the style fixes are OK on earlier versions.